### PR TITLE
implemented Flash Messenger with HTTP Cookie storage

### DIFF
--- a/MvcFlash.Core/Extensions/HtmlHelperExtensions.cs
+++ b/MvcFlash.Core/Extensions/HtmlHelperExtensions.cs
@@ -11,11 +11,16 @@ namespace MvcFlash.Core.Extensions
             var popper = DependencyResolver.Current.GetService<IFlashMessenger>()
                 ?? Core.Flash.Instance;
 
+            return Flash(helper, popper);
+        }        
+        
+        public static MvcHtmlString Flash<TModel>(this HtmlHelper<TModel> helper, IFlashMessenger flashMessenger)
+        {
             var builder = new StringBuilder();
 
-            while (popper.Count > 0)
+            while (flashMessenger.Count > 0)
             {
-                var message = popper.Pop();
+                var message = flashMessenger.Pop();
                 builder.AppendLine(string.IsNullOrWhiteSpace(message.Template)
                                        ? helper.DisplayFor(m => message).ToString()
                                        : helper.DisplayFor(m => message, message.Template).ToString());
@@ -23,6 +28,8 @@ namespace MvcFlash.Core.Extensions
 
             return MvcHtmlString.Create(builder.ToString());
         }
+
+
 
         public static T Cast<T>(this object value)
         {

--- a/MvcFlash.Core/MvcFlash.Core.csproj
+++ b/MvcFlash.Core/MvcFlash.Core.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.Helpers.dll</HintPath>
@@ -83,6 +84,7 @@
     <Compile Include="IFlashMessenger.cs" />
     <Compile Include="Messages\MessageBase.cs" />
     <Compile Include="Messages\SimpleMessage.cs" />
+    <Compile Include="Providers\CookieStorageFlashMessenger.cs" />
     <Compile Include="Providers\FlashMessengerBase.cs" />
     <Compile Include="Providers\HttpSessionFlashMessenger.cs" />
     <Compile Include="Providers\InMemoryFlashMessenger.cs" />

--- a/MvcFlash.Core/Providers/CookieStorageFlashMessenger.cs
+++ b/MvcFlash.Core/Providers/CookieStorageFlashMessenger.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Script.Serialization;
+using MvcFlash.Core.Messages;
+
+namespace MvcFlash.Core.Providers
+{
+    public class CookieStorageFlashMessenger : IFlashMessenger
+    {
+        private readonly ICookieProvider _cookieProvider;
+        private readonly string _cookieName;
+
+        private IDictionary<string, SimpleMessage> _messages;
+
+        public CookieStorageFlashMessenger(ICookieProvider cookieProvider, string cookieName = "__FlashCookie__")
+        {
+            _cookieProvider = cookieProvider;
+            _cookieName = cookieName;
+        }
+
+        public MessageBase Push(MessageBase message)
+        {
+            if (message == null)
+                throw new ArgumentNullException("message", "message cannot be null");
+
+            var simpleMessage = message as SimpleMessage;
+
+            if(simpleMessage == null)
+                throw new ArgumentException("Cookie Flash Storage only allows instances of SimpleMessage to be used!", "message");
+            
+            EnsureDataLoadedFromRequestCookie();
+
+            _messages[message.Id] = (SimpleMessage)message;
+
+            SaveExistingMessagesToResponseCookie();
+
+            return message;
+        }
+
+        public MessageBase Pop()
+        {
+            EnsureDataLoadedFromRequestCookie();
+
+            var messageKey = _messages.Keys.LastOrDefault();
+
+            if (messageKey == null)
+                return null;
+
+            var message = _messages[messageKey];
+            _messages.Remove(messageKey);
+
+            SaveExistingMessagesToResponseCookie();
+            
+            return message;
+        }
+
+        public int Count
+        {
+            get
+            {
+                EnsureDataLoadedFromRequestCookie();
+                return _messages.Count;
+            }
+        }
+
+        public void Clear()
+        {
+            _messages = new Dictionary<string, SimpleMessage>();
+
+            var eraseCookie = new HttpCookie(_cookieName)
+            {
+                Expires = DateTime.Now.AddYears(-1)
+            };
+
+            _cookieProvider.SetResponseCookie(eraseCookie);
+        }
+
+
+        private void EnsureDataLoadedFromRequestCookie()
+        {
+            if(_messages != null)
+                return;
+
+            var requestCookie = _cookieProvider.GetRequestCookie(_cookieName);
+
+            if (requestCookie == null)
+            {
+                _messages = new Dictionary<string, SimpleMessage>();
+                return;                
+            }
+
+            var serializer = new JavaScriptSerializer();
+
+            _messages = serializer.Deserialize<Dictionary<string, SimpleMessage>>(requestCookie.Value);
+        }
+
+        private void SaveExistingMessagesToResponseCookie()
+        {
+            var value = new JavaScriptSerializer().Serialize(_messages);
+
+            var responseCookie = new HttpCookie(_cookieName, value);
+
+            _cookieProvider.SetResponseCookie(responseCookie);
+        }
+    }
+
+    public interface ICookieProvider
+    {
+        HttpCookie GetRequestCookie(string cookieName);
+        void SetResponseCookie(HttpCookie cookie);
+    }
+
+    public class HttpCookieProvider : ICookieProvider
+    {
+        public HttpCookie GetRequestCookie(string cookieName)
+        {
+            return HttpContext.Current.Request.Cookies[cookieName];
+        }
+
+        public void SetResponseCookie(HttpCookie cookie)
+        {
+            HttpContext.Current.Response.Cookies.Set(cookie);
+        }
+    }
+}

--- a/MvcFlash.Sample/Controllers/CookieStorageController.cs
+++ b/MvcFlash.Sample/Controllers/CookieStorageController.cs
@@ -1,0 +1,25 @@
+﻿using System.Web.Mvc;
+using MvcFlash.Core;
+using MvcFlash.Core.Providers;
+using MvcFlash.Sample.Models;
+
+namespace MvcFlash.Sample.Controllers
+{
+    public class CookieStorageController : Controller
+    {
+        private readonly IFlashMessenger _cookieFlashMessenger = 
+            new CookieStorageFlashMessenger(new HttpCookieProvider());
+
+        public ActionResult Index()
+        {
+            return View(_cookieFlashMessenger);
+        }
+
+        public ActionResult SetFlashAndRedirect(CookieFlashModel model)
+        {
+            _cookieFlashMessenger.Push(model.ToSimpleMessage());
+            
+            return RedirectToAction("Index");
+        }
+    }
+}

--- a/MvcFlash.Sample/Models/CookieFlashModel.cs
+++ b/MvcFlash.Sample/Models/CookieFlashModel.cs
@@ -1,0 +1,21 @@
+﻿using MvcFlash.Core.Messages;
+
+namespace MvcFlash.Sample.Models
+{
+    public class CookieFlashModel
+    {
+        public string Type { get; set; } 
+        public string Title { get; set; }
+        public string Content { get; set; }
+
+        public SimpleMessage ToSimpleMessage()
+        {
+            return new SimpleMessage
+            {
+                MessageType = Type,
+                Title = Title ?? "[empty title]",
+                Content = Content ?? "Enter a message, don't be so shy!"
+            };
+        }
+    }
+}

--- a/MvcFlash.Sample/MvcFlash.Sample.csproj
+++ b/MvcFlash.Sample/MvcFlash.Sample.csproj
@@ -118,6 +118,7 @@
   <ItemGroup>
     <Compile Include="App_Start\StructuremapMvc.cs" />
     <Compile Include="Controllers\ApplicationController.cs" />
+    <Compile Include="Controllers\CookieStorageController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Controllers\IoCController.cs" />
     <Compile Include="Controllers\TricksController.cs" />
@@ -128,6 +129,7 @@
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
+    <Compile Include="Models\CookieFlashModel.cs" />
     <Compile Include="Models\FlashImage.cs" />
     <Compile Include="DependencyResolution\Registries\FlashRegistry.cs" />
     <Compile Include="Models\RelatedPages.cs" />
@@ -166,6 +168,7 @@
     <Content Include="Views\Tricks\Index.cshtml" />
     <Content Include="Views\Shared\DisplayTemplates\HelpfulLinks.cshtml" />
     <Content Include="Views\Shared\DisplayTemplates\SimpleMessage.cshtml" />
+    <Content Include="Views\CookieStorage\Index.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />

--- a/MvcFlash.Sample/Views/CookieStorage/Index.cshtml
+++ b/MvcFlash.Sample/Views/CookieStorage/Index.cshtml
@@ -1,0 +1,34 @@
+﻿@model MvcFlash.Core.IFlashMessenger
+@{
+    ViewBag.Title = "Flash with HTTP Cookie Storage";
+}
+
+<h2>Flash with HTTP Cookie Storage</h2>
+
+@using (Html.BeginForm("SetFlashAndRedirect", "CookieStorage"))
+{
+    <fieldset>
+        <label>Flash Type</label>
+        <select name="type">
+            <option>info</option>
+            <option>error</option>
+            <option>warning</option>
+        </select>
+
+        <label>Flash Title</label>
+        <input type="text" name="title" placeholder="Type message title here…">
+        
+        <label>Flash Message</label>
+        <input type="text" name="content" placeholder="Type message here…">
+
+        <br/>
+
+        <button type="submit" class="btn">Submit</button>
+    </fieldset>
+
+}
+
+@Html.Flash(Model)
+
+
+@Html.ActionLink("Refresh page (popped messages will be cleared)", "Index")

--- a/MvcFlash.Sample/Views/Shared/_Layout.cshtml
+++ b/MvcFlash.Sample/Views/Shared/_Layout.cshtml
@@ -42,6 +42,7 @@
                         <li><a href="@Url.Action("index", "WithBase")">With Base</a></li>
                         <li><a href="@Url.Action("index", "IoC")">IoC</a></li>
                         <li><a href="@Url.Action("index", "Tricks")">Tricks</a></li>
+                        <li><a href="@Url.Action("index", "CookieStorage")">Cookie Storage</a></li>
                     </ul>
                 </div>
                 <!--/.nav-collapse -->

--- a/MvcFlash.Tests/MvcFlash.Tests.csproj
+++ b/MvcFlash.Tests/MvcFlash.Tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Fakes.cs" />
     <Compile Include="FilterTests.cs" />
     <Compile Include="FlashApiTests.cs" />
+    <Compile Include="Providers\CookieStorageFlashMessengerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MvcFlash.Core\MvcFlash.Core.csproj">

--- a/MvcFlash.Tests/Providers/CookieStorageFlashMessengerTests.cs
+++ b/MvcFlash.Tests/Providers/CookieStorageFlashMessengerTests.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using System.Web;
+using FluentAssertions;
+using MvcFlash.Core.Messages;
+using MvcFlash.Core.Providers;
+using Xunit;
+
+namespace MvcFlash.Tests.Providers
+{
+    public class CookieStorageFlashMessengerTests
+    {
+        private CookieStorageFlashMessenger _sut;
+        private FakeCookieProvider _cookieProvider;
+        private string _cookieName = "__FLASH__";
+
+        public CookieStorageFlashMessengerTests()
+        {
+            CreateSystemUnderTest();
+        }
+
+        [Fact]
+        public void Initial_count_is_zero()
+        {
+            _sut.Count.ShouldBeEquivalentTo(0);
+        }
+
+        [Fact]
+        public void Initially_there_is_no_cookie_in_the_response()
+        {
+            ResponseCookieValue().Should().BeNull();
+        }
+
+        [Fact]
+        public void After_adding_message_cookie_is_present_in_reponse()
+        {
+            _sut.Push(new SimpleMessage {MessageType = "info", Title = "Hello"});
+
+            ResponseCookieValue().Should().Contain("\"MessageType\":\"info\"");
+            ResponseCookieValue().Should().Contain("\"Title\":\"Hello\"");
+        }
+
+        [Fact]
+        public void Adding_null_message_throws_exception()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => _sut.Push(null));
+
+            exception.Message.ShouldBeEquivalentTo("message cannot be null\r\nParameter name: message");
+        }
+
+        [Fact]
+        public void Adding_message_of_wrong_type_throws_exception()
+        {
+            var exception = Assert.Throws<ArgumentException>(
+                () => _sut.Push(new OtherTypeOfMessage()));
+
+            exception.Message.ShouldBeEquivalentTo(
+                "Cookie Flash Storage only allows instances of SimpleMessage to be used!\r\nParameter name: message");
+        }
+
+        [Fact]
+        public void After_adding_two_messages_both_present_in_response_cookie()
+        {
+            _sut.Push(new SimpleMessage { Title = "hello" });
+            _sut.Push(new SimpleMessage { Title = "world" });
+
+            Console.WriteLine(ResponseCookieValue());
+
+            ResponseCookieValue().Should().Contain("\"Title\":\"hello\"");
+            ResponseCookieValue().Should().Contain("\"Title\":\"world\"");
+        }
+
+        [Fact]
+        public void After_adding_messages_count_is_correct()
+        {
+            _sut.Count.ShouldBeEquivalentTo(0);
+            _sut.Push(new SimpleMessage { Title = "hello" });
+            _sut.Count.ShouldBeEquivalentTo(1);
+            _sut.Push(new SimpleMessage { Title = "world" });
+            _sut.Count.ShouldBeEquivalentTo(2);
+        }
+
+        [Fact]
+        public void Message_already_present_count_is_correct()
+        {
+            SetRequestCookieValue(@"{'m1':{'Id':'m1','Title':'hello'}}");
+
+            _sut.Count.ShouldBeEquivalentTo(1);
+        }
+
+        [Fact]
+        public void Two_messages_already_present_count_is_correct()
+        {
+            SetRequestCookieValue(
+                @"{'m1':{'Id':'m1','Title':'hello'}, 'm2':{'Id':'m2','Title':'world'}}");
+
+            _sut.Count.ShouldBeEquivalentTo(2);
+        }
+
+        [Fact]
+        public void Pop_returns_null_if_no_messages_available()
+        {
+            _sut.Pop().Should().BeNull();
+        }
+
+        [Fact]
+        public void Pop_returns_message_already_present()
+        {
+            SetRequestCookieValue(@"{'m1':{'Id':'m1','Title':'hello'}}");
+
+            var message = _sut.Pop();
+
+            message.Id.ShouldBeEquivalentTo("m1");
+            message.Title.ShouldBeEquivalentTo("hello");
+        }
+
+        [Fact]
+        public void Pop_returns_message_just_added()
+        {
+            _sut.Push(new SimpleMessage {Id = "m1", Title = "hello"});
+
+            var message = _sut.Pop();
+
+            message.Id.ShouldBeEquivalentTo("m1");
+            message.Title.ShouldBeEquivalentTo("hello");
+        }
+
+        [Fact]
+        public void After_pop_count_is_decremented()
+        {
+            _sut.Push(new SimpleMessage {Id = "m1", Title = "hello"});
+            _sut.Push(new SimpleMessage {Id = "m2", Title = "world"});
+
+            _sut.Count.ShouldBeEquivalentTo(2);
+
+            _sut.Pop();
+            _sut.Count.ShouldBeEquivalentTo(1);
+            _sut.Pop();
+            _sut.Count.ShouldBeEquivalentTo(0);
+            _sut.Pop();
+            _sut.Count.ShouldBeEquivalentTo(0);
+        }
+
+        [Fact]
+        public void No_message_recently_added_Response_cookie_not_set()
+        {
+            SetRequestCookieValue(@"{'m1':{'Id':'m1','Title':'hello'}}");
+
+            ResponseCookieValue().Should().BeNull();
+        }
+
+        [Fact]
+        public void Message_available_and_new_one_added_added_Response_cookie_contains_both()
+        {
+            SetRequestCookieValue(@"{'m1':{'Id':'m1','Title':'hello'}}");
+            _sut.Push(new SimpleMessage { Id = "m2", Title = "world" });
+
+            ResponseCookieValue().Should().Contain("\"Title\":\"hello\"");
+            ResponseCookieValue().Should().Contain("\"Title\":\"world\"");
+        }
+
+        [Fact]
+        public void Two_messages_available_Popping_one_sets_response_cookie()
+        {
+            SetRequestCookieValue(
+                @"{'m1':{'Id':'m1','Title':'hello'}, 'm2':{'Id':'m2','Title':'world'}}");
+
+            _sut.Pop();
+
+            ResponseCookieValue().Should().Contain("\"Title\":\"hello\"");
+        }
+
+        [Fact]
+        public void Calling_Clear_discards_messages_and_saves_expired_response_cookie()
+        {
+            SetRequestCookieValue(
+                @"{'m1':{'Id':'m1','Title':'hello'}, 'm2':{'Id':'m2','Title':'world'}}");
+
+            _sut.Clear();
+
+            var yesterday = DateTime.Now.AddDays(-1);
+
+            ResponseCookie().Expires.Should().BeBefore(yesterday);
+            ResponseCookieValue().Should().BeNullOrEmpty();
+        }
+
+        [Fact]
+        public void Calling_Clear_resets_count()
+        {
+            SetRequestCookieValue(
+                @"{'m1':{'Id':'m1','Title':'hello'}, 'm2':{'Id':'m2','Title':'world'}}");
+
+            _sut.Clear();
+
+            _sut.Count.ShouldBeEquivalentTo(0);
+        }
+
+        
+
+        private void CreateSystemUnderTest()
+        {
+            _cookieProvider = new FakeCookieProvider();
+            _sut = new CookieStorageFlashMessenger(_cookieProvider, _cookieName);
+        }
+        private HttpCookie ResponseCookie()
+        {
+            return _cookieProvider.ResponseCookies[_cookieName];
+        }
+        private string ResponseCookieValue()
+        {
+            return ResponseCookie() != null ? ResponseCookie().Value : null;
+        }
+        private void SetRequestCookieValue(string value)
+        {
+            _cookieProvider.RequestCookies.Set(new HttpCookie(_cookieName, value));
+        }
+
+        internal class FakeCookieProvider : ICookieProvider
+        {
+            public FakeCookieProvider()
+            {
+                RequestCookies = new HttpCookieCollection();
+                ResponseCookies = new HttpCookieCollection();
+            }
+
+            public HttpCookieCollection RequestCookies { get; private set; }
+            public HttpCookieCollection ResponseCookies { get; private set; }
+
+            public HttpCookie GetRequestCookie(string cookieName)
+            {
+                return RequestCookies[cookieName];
+            }
+
+            public void SetResponseCookie(HttpCookie cookie)
+            {
+                ResponseCookies.Set(cookie);
+            }
+        }
+
+        public class OtherTypeOfMessage : MessageBase { }
+    }
+}


### PR DESCRIPTION
This pull request contains a new implementation of `IFlashMessenger` which uses HTTP Cookies as storage mechanism, as opposed to the ASP.NET Session or an in-memory dictionary.

From the server's point of view, this can be seen as a "stateless" implementation of Flash messages, and could be beneficial in case a web application is hosted on more machines with no preexisting shared session state mechanism.
